### PR TITLE
Fallback checking

### DIFF
--- a/dist/spatialNavigation.js
+++ b/dist/spatialNavigation.js
@@ -250,7 +250,7 @@ var SpatialNavigation = function () {
         var lastFocusedChildKey = targetComponent.lastFocusedChildKey;
 
 
-        if (lastFocusedChildKey && this.focusableComponents[lastFocusedChildKey]) {
+        if (lastFocusedChildKey && this.isFocusableComponent(lastFocusedChildKey)) {
           this.onIntermediateNodeBecameFocused(targetFocusKey);
 
           return this.getNextFocusKey(lastFocusedChildKey);
@@ -349,7 +349,7 @@ var SpatialNavigation = function () {
   }, {
     key: 'updateLayout',
     value: function updateLayout(focusKey, layout) {
-      if (this.focusableComponents[focusKey]) {
+      if (this.isFocusableComponent(focusKey)) {
         this.focusableComponents[focusKey].layout = layout;
       }
     }
@@ -416,12 +416,17 @@ var SpatialNavigation = function () {
   }, {
     key: 'isPropagateFocus',
     value: function isPropagateFocus(focusKey) {
-      return this.focusableComponents[focusKey] && this.focusableComponents[focusKey].propagateFocus;
+      return this.isFocusableComponent(focusKey) && this.focusableComponents[focusKey].propagateFocus;
+    }
+  }, {
+    key: 'isFocusableComponent',
+    value: function isFocusableComponent(focusKey) {
+      return !!this.focusableComponents[focusKey];
     }
   }, {
     key: 'onIntermediateNodeBecameFocused',
     value: function onIntermediateNodeBecameFocused(focusKey) {
-      this.focusableComponents[focusKey] && this.focusableComponents[focusKey].onBecameFocusedHandler(this.getNodeLayoutByFocusKey(focusKey));
+      this.isFocusableComponent(focusKey) && this.focusableComponents[focusKey].onBecameFocusedHandler(this.getNodeLayoutByFocusKey(focusKey));
     }
   }]);
 

--- a/dist/withSpatialNavigation.js
+++ b/dist/withSpatialNavigation.js
@@ -50,7 +50,7 @@ var withSpatialNavigation = function withSpatialNavigation() {
 
       /**
        * This collection contains focus keys of the elements that are having a child focused
-       * Might be handy for styling of certain parent components if their child is focused
+       * Might be handy for styling of certain parent components if their child is focused.
        */
       parentsHavingFocusedChild: []
     }, {
@@ -58,7 +58,8 @@ var withSpatialNavigation = function withSpatialNavigation() {
         var currentFocusKey = _ref2.currentFocusKey,
             parentsHavingFocusedChild = _ref2.parentsHavingFocusedChild;
         return function (focusKey, overwriteFocusKey) {
-          var targetFocusKey = overwriteFocusKey || focusKey;
+          // if there exists an overriding focusKey then use it, but only if it exists in the SP service.
+          var targetFocusKey = overwriteFocusKey && _spatialNavigation2.default.isFocusableComponent(overwriteFocusKey) ? overwriteFocusKey : focusKey;
 
           if (currentFocusKey !== targetFocusKey) {
             var newFocusKey = _spatialNavigation2.default.getNextFocusKey(targetFocusKey);

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -196,7 +196,7 @@ class SpatialNavigation {
        */
       const {lastFocusedChildKey} = targetComponent;
 
-      if (lastFocusedChildKey && this.focusableComponents[lastFocusedChildKey]) {
+      if (lastFocusedChildKey && this.isFocusableComponent(lastFocusedChildKey)) {
         this.onIntermediateNodeBecameFocused(targetFocusKey);
 
         return this.getNextFocusKey(lastFocusedChildKey);
@@ -276,7 +276,7 @@ class SpatialNavigation {
   }
 
   updateLayout(focusKey, layout) {
-    if (this.focusableComponents[focusKey]) {
+    if (this.isFocusableComponent(focusKey)) {
       this.focusableComponents[focusKey].layout = layout;
     }
   }
@@ -336,11 +336,15 @@ class SpatialNavigation {
   }
 
   isPropagateFocus(focusKey) {
-    return this.focusableComponents[focusKey] && this.focusableComponents[focusKey].propagateFocus;
+    return this.isFocusableComponent(focusKey) && this.focusableComponents[focusKey].propagateFocus;
+  }
+
+  isFocusableComponent(focusKey) {
+    return !!this.focusableComponents[focusKey];
   }
 
   onIntermediateNodeBecameFocused(focusKey) {
-    this.focusableComponents[focusKey] &&
+    this.isFocusableComponent(focusKey) &&
       this.focusableComponents[focusKey].onBecameFocusedHandler(this.getNodeLayoutByFocusKey(focusKey));
   }
 }

--- a/src/withSpatialNavigation.js
+++ b/src/withSpatialNavigation.js
@@ -18,12 +18,14 @@ const withSpatialNavigation = ({keyMap} = {}) => (BaseComponent) => {
 
       /**
        * This collection contains focus keys of the elements that are having a child focused
-       * Might be handy for styling of certain parent components if their child is focused
+       * Might be handy for styling of certain parent components if their child is focused.
        */
       parentsHavingFocusedChild: []
     }, {
       setFocus: ({currentFocusKey, parentsHavingFocusedChild}) => (focusKey, overwriteFocusKey) => {
-        const targetFocusKey = overwriteFocusKey || focusKey;
+        // if there exists an overriding focusKey then use it, but only if it exists in the SP service.
+        const targetFocusKey = overwriteFocusKey && SpatialNavigation.isFocusableComponent(overwriteFocusKey) ?
+          overwriteFocusKey : focusKey;
 
         if (currentFocusKey !== targetFocusKey) {
           const newFocusKey = SpatialNavigation.getNextFocusKey(targetFocusKey);


### PR DESCRIPTION
* Added fallback in setFocus which checks whether or not the overwriteFocusKey exitst before setting it as the target focusKey. This means that there is less chance of unnecessary recursions occurring.

* Used the new isFocusable component function check in the actual SpatialNavigation service for readability.