### PR TITLE
Move react-native-web, react-dom and react to peerDependencies, with appropriate version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
     "url": "https://github.com/NoriginMedia/react-spatial-navigation/issues"
   },
   "homepage": "https://github.com/NoriginMedia/react-spatial-navigation#readme",
+  "peerDependencies": {
+    "react": ">=16.5.1",
+    "react-dom": ">=16.5.1",
+    "react-native-web": "^0.11.2"
+  },
   "dependencies": {
     "lodash": "^4.17.0",
     "prop-types": "^15.6.2",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
     "recompose": "^0.30.0"
   },
   "devDependencies": {
@@ -43,6 +46,8 @@
     "eslint-config-norigin": "git+https://github.com/NoriginMedia/eslint-config-norigin.git#v3.7.0",
     "parcel-bundler": "^1.11.0",
     "pre-commit": "^1.2.2",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
     "react-native-web": "^0.11.2"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "hoc"
   ],
   "author": "Dmitriy Bryokhin <dmitriy.bryokhin@noriginmedia.com>",
+  "contributors": [
+    "Dmitriy Bryokhin <dmitriy.bryokhin@noriginmedia.com>",
+    "Jamie Birch <jamie.birch@s-and-t.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/NoriginMedia/react-spatial-navigation/issues"


### PR DESCRIPTION
# Description

There are two changes:

1. Make the version ranges of `react-dom` and `react` more permissive
2. Move `react`, `react-dom`, and `react-native-web` to `peerDependencies`

The first change prevents duplication of React and React DOM dependencies by relaxing the version constraints. This is exactly how React Native Web `v0.11.2` itself describes its dependency ranges – and as this library is inheriting from RNW, it makes sense to follow their conventions.

The second change allows the consumer of `react-spatial-navigation` to supply their own React, React DOM, and React Native Web dependencies; this means that the versions of those three packages are no longer dictated by this library, so the dev is responsible (but now free) to decide which version of each package they want to use, by supplying it themselves.

# Purpose

I use newer versions of React and React DOM in my RNW project, so I found that upon including `react-spatial-navigation`, it was bundling multiple separate versions of those two packages to satisfy the dependency constraints. In any React app, it only makes sense for there to be one copy of React, React DOM, and RNW, so these changes arrange for that to be the case.

# `react-native-web` versioning

I've provisionally chosen to set `react-native-web` with a `^` range (as you've done before), but we could potentially be more bold with the version range depending on the likelihood of a breaking change.

I think `^` is reasonable and safe, though it may prove more restrictive than necessary – `~` may be more appropriate, but normal semver versioning logic doesn't apply until the first stable release (version 1.0.0). So at the very least, this range is no worse than before.

So we can either re-assess and update the permitted range accordingly each time a new RNW version comes out, or set the range as `>=0.11.2` and just hope for the best. For discussion.

**EDIT:** Now that I think of it, `>=0.11.2` sounds like the policy with the lowest maintenance involved. If ever a truly breaking change is encountered in RNW, a new `react-spatial-navigation` package can be published that re-addresses that version range. Should I apply this change to the PR?