### PR TITLE
Support component-level "enabled" prop to restrict spatial navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,10 @@ Same as in [config](#config).
 ### `forgetLastFocusedChild`: boolean
 Same as in [config](#config).
 
-### `enabled`: boolean
-Determine whether this component should be focusable. This allows a focusable component to be ignored as a navigation target despite being mounted (e.g. due to being off-screen, hidden, or temporarily disabled).
+### `focusable`: boolean
+Determine whether this component should be focusable (in other words, whether it's *currently* participating in the spatial navigation tree). This allows a focusable component to be ignored as a navigation target despite being mounted (e.g. due to being off-screen, hidden, or temporarily disabled).
 
-Note that behaviour is undefined for trees of components in which an `enabled={false}` component has any `enabled={true}` components as descendants; it is recommended to ensure that all components in a given branch of the spatial navigation tree have a common `enabled` state.    
+Note that behaviour is undefined for trees of components in which an `focusable={false}` component has any `focusable={true}` components as descendants; it is recommended to ensure that all components in a given branch of the spatial navigation tree have a common `focusable` state.    
 
 * **false**
 * **true (default)**

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Same as in [config](#config).
 ### `enabled`: boolean
 Determine whether this component should be focusable. This allows a focusable component to be ignored as a navigation target despite being mounted (e.g. due to being off-screen, hidden, or temporarily disabled).
 
+Note that behaviour is undefined for trees of components in which an `enabled={false}` component has any `enabled={true}` components as descendants; it is recommended to ensure that all components in a given branch of the spatial navigation tree have a common `enabled` state.    
+
 * **false**
 * **true (default)**
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ Same as in [config](#config).
 ### `forgetLastFocusedChild`: boolean
 Same as in [config](#config).
 
+### `enabled`: boolean
+Determine whether this component should be focusable. This allows a focusable component to be ignored as a navigation target despite being mounted (e.g. due to being off-screen, hidden, or temporarily disabled).
+
+* **false**
+* **true (default)**
+
 ### `focusKey`: string
 String that is used as a component focus key. Should be **unique**, otherwise it will override previously stored component with the same focus key in the Spatial Navigation service storage of focusable components. If this is not specified, the focus key will be generated automatically.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "hoc"
   ],
   "author": "Dmitriy Bryokhin <dmitriy.bryokhin@noriginmedia.com>",
+  "contributors": [
+    "Dmitriy Bryokhin <dmitriy.bryokhin@noriginmedia.com>",
+    "Jamie Birch <jamie.birch@s-and-t.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/NoriginMedia/react-spatial-navigation/issues"

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -466,6 +466,7 @@ class SpatialNavigation {
       currentComponent ? currentComponent.node : undefined
     );
 
+    /* We will not check whether currentComponent is enabled; it's fine to navigate AWAY from a disabled component. */
     if (currentComponent) {
       const {parentFocusKey, focusKey, layout} = currentComponent;
 
@@ -543,6 +544,7 @@ class SpatialNavigation {
   }
 
   saveLastFocusedChildKey(component, focusKey) {
+    /* We won't check whether component is enabled; it's fine to save a disabled component as the lastFocusedChild. */
     if (component) {
       this.log('saveLastFocusedChildKey', `${component.focusKey} lastFocusedChildKey set`, focusKey);
       component.lastFocusedChildKey = focusKey;

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -843,6 +843,12 @@ class SpatialNavigation {
     const lastFocusedKey = this.focusKey;
     const newFocusKey = this.getNextFocusKey(targetFocusKey);
 
+    if (!this.isEnabledFocusableComponent(newFocusKey)) {
+      this.log('setFocus', 'noEnabledFocusTargets', newFocusKey);
+
+      return;
+    }
+
     this.log('setFocus', 'newFocusKey', newFocusKey);
 
     this.setCurrentFocusedKey(newFocusKey);

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -575,7 +575,10 @@ class SpatialNavigation {
       return targetFocusKey;
     }
 
-    const children = filter(this.focusableComponents, (component) => component.parentFocusKey === targetFocusKey);
+    const children = filter(
+      this.focusableComponents,
+      (component) => component.parentFocusKey === targetFocusKey && component.enabled
+    );
 
     if (children.length > 0) {
       this.onIntermediateNodeBecameFocused(targetFocusKey);
@@ -590,7 +593,7 @@ class SpatialNavigation {
        */
       if (lastFocusedChildKey &&
         !targetComponent.forgetLastFocusedChild &&
-        this.isFocusableComponent(lastFocusedChildKey)
+        this.isEnabledFocusableComponent(lastFocusedChildKey)
       ) {
         this.log('getNextFocusKey', 'lastFocusedChildKey will be focused', lastFocusedChildKey);
 
@@ -600,7 +603,7 @@ class SpatialNavigation {
       /**
        * If there is no lastFocusedChild, trying to focus the preferred focused key
        */
-      if (preferredChildFocusKey && this.isFocusableComponent(preferredChildFocusKey)) {
+      if (preferredChildFocusKey && this.isEnabledFocusableComponent(preferredChildFocusKey)) {
         this.log('getNextFocusKey', 'preferredChildFocusKey will be focused', preferredChildFocusKey);
 
         return this.getNextFocusKey(preferredChildFocusKey);
@@ -719,7 +722,7 @@ class SpatialNavigation {
   }
 
   setCurrentFocusedKey(focusKey) {
-    if (this.isFocusableComponent(this.focusKey) && focusKey !== this.focusKey) {
+    if (this.isEnabledFocusableComponent(this.focusKey) && focusKey !== this.focusKey) {
       const oldComponent = this.focusableComponents[this.focusKey];
       const parentComponent = this.focusableComponents[oldComponent.parentFocusKey];
 
@@ -809,8 +812,12 @@ class SpatialNavigation {
     return !!this.focusableComponents[focusKey];
   }
 
+  isEnabledFocusableComponent(focusKey) {
+    return this.isFocusableComponent(focusKey) && this.focusableComponents[focusKey].enabled;
+  }
+
   onIntermediateNodeBecameFocused(focusKey) {
-    this.isFocusableComponent(focusKey) &&
+    this.isEnabledFocusableComponent(focusKey) &&
       this.focusableComponents[focusKey].onBecameFocusedHandler(this.getNodeLayoutByFocusKey(focusKey));
   }
 

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -432,6 +432,13 @@ class SpatialNavigation {
   onEnterPress() {
     const component = this.focusableComponents[this.focusKey];
 
+    /* Suppress onEnterPress if the focused item happens to lose its 'enabled' status. */
+    if (!component.enabled) {
+      this.log('onEnterPress', 'componentNotEnabled');
+
+      return;
+    }
+
     component.onEnterPressHandler && component.onEnterPressHandler();
   }
 

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -483,7 +483,7 @@ class SpatialNavigation {
        * Get only the siblings with the coords on the way of our moving direction
        */
       const siblings = filter(this.focusableComponents, (component) => {
-        if (component.parentFocusKey === parentFocusKey) {
+        if (component.parentFocusKey === parentFocusKey && component.enabled) {
           const siblingCutoffCoordinate = SpatialNavigation.getCutoffCoordinate(
             isVerticalDirection,
             isIncrementalDirection,
@@ -637,7 +637,8 @@ class SpatialNavigation {
     trackChildren,
     onUpdateFocus,
     onUpdateHasFocusedChild,
-    preferredChildFocusKey
+    preferredChildFocusKey,
+    enabled
   }) {
     this.focusableComponents[focusKey] = {
       focusKey,
@@ -652,6 +653,7 @@ class SpatialNavigation {
       trackChildren,
       lastFocusedChildKey: null,
       preferredChildFocusKey,
+      enabled,
       layout: {
         x: 0,
         y: 0,
@@ -874,7 +876,7 @@ class SpatialNavigation {
     });
   }
 
-  updateFocusable(focusKey, {node, preferredChildFocusKey}) {
+  updateFocusable(focusKey, {node, preferredChildFocusKey, enabled}) {
     if (this.nativeMode) {
       return;
     }
@@ -883,6 +885,7 @@ class SpatialNavigation {
 
     if (component) {
       component.preferredChildFocusKey = preferredChildFocusKey;
+      component.enabled = enabled;
 
       if (node) {
         component.node = node;

--- a/src/withFocusable.js
+++ b/src/withFocusable.js
@@ -121,7 +121,9 @@ const withFocusable = ({
       });
     },
     componentDidUpdate(prevProps) {
-      const {focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey, enabled = true} = this.props;
+      const {
+        focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey, enabled = true
+      } = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? null : findDOMNode(this);
 

--- a/src/withFocusable.js
+++ b/src/withFocusable.js
@@ -100,7 +100,7 @@ const withFocusable = ({
         onUpdateFocus,
         onUpdateHasFocusedChild,
         trackChildren,
-        enabled = true
+        focusable = true
       } = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? null : findDOMNode(this);
@@ -117,12 +117,12 @@ const withFocusable = ({
         onUpdateHasFocusedChild,
         forgetLastFocusedChild: (configForgetLastFocusedChild || forgetLastFocusedChild),
         trackChildren: (configTrackChildren || trackChildren),
-        enabled
+        focusable
       });
     },
     componentDidUpdate(prevProps) {
       const {
-        focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey, enabled = true
+        focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey, focusable = true
       } = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? null : findDOMNode(this);
@@ -130,7 +130,7 @@ const withFocusable = ({
       SpatialNavigation.updateFocusable(focusKey, {
         node,
         preferredChildFocusKey,
-        enabled
+        focusable
       });
 
       if (!prevProps.focused && focused) {

--- a/src/withFocusable.js
+++ b/src/withFocusable.js
@@ -99,7 +99,8 @@ const withFocusable = ({
         onBecameFocusedHandler,
         onUpdateFocus,
         onUpdateHasFocusedChild,
-        trackChildren
+        trackChildren,
+        enabled = true
       } = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? null : findDOMNode(this);
@@ -115,17 +116,19 @@ const withFocusable = ({
         onUpdateFocus,
         onUpdateHasFocusedChild,
         forgetLastFocusedChild: (configForgetLastFocusedChild || forgetLastFocusedChild),
-        trackChildren: (configTrackChildren || trackChildren)
+        trackChildren: (configTrackChildren || trackChildren),
+        enabled
       });
     },
     componentDidUpdate(prevProps) {
-      const {focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey} = this.props;
+      const {focused, realFocusKey: focusKey, onBecameFocusedHandler, preferredChildFocusKey, enabled = true} = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? null : findDOMNode(this);
 
       SpatialNavigation.updateFocusable(focusKey, {
         node,
-        preferredChildFocusKey
+        preferredChildFocusKey,
+        enabled
       });
 
       if (!prevProps.focused && focused) {


### PR DESCRIPTION
Partly addresses #23.

* `enabled` is an optional prop that defaults to `true`.
* Any component that has `enabled={false}` will not be considered as a navigation target.
• If `setFocus()` or `stealFocus()` is called and resolves to a component with `enabled={false}`, then it will no-op.
* If a component was initially focused while `enabled={true}` but enabled becomes `false` whilst that focus is held, it *is* permitted to navigate away from that disabled component to the next enabled component.
* If `KEY_ENTER` is pressed on a component that has lost `enabled` state (as above) then `onEnterPress` will be suppressed.
* It is possible – although not recommended – to have a parent with `enabled={false}` bearing a child or descendant with `enabled={true}`. In such case, the behaviour is undefined, but I think in practice the focus will still drill down to that enabled child, which is probably sensible enough. For an easy life, it is recommended for the user to ensure that all focusable components in any branch of a focusable component tree share the same `enabled` value.