### PR TITLE
Handle keypresses safely for focusables that become unmounted.

### DIFF
--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -432,7 +432,14 @@ class SpatialNavigation {
   onEnterPress() {
     const component = this.focusableComponents[this.focusKey];
 
-    /* Suppress onEnterPress if the focused item happens to lose its 'focused' status. */
+    /* Guard against last-focused component being unmounted at time of onEnterPress (e.g due to UI fading out) */
+    if (!component) {
+      this.log('onEnterPress', 'noComponent');
+
+      return;
+    }
+
+    /* Suppress onEnterPress if the last-focused item happens to lose its 'focused' status. */
     if (!component.focusable) {
       this.log('onEnterPress', 'componentNotFocusable');
 
@@ -444,6 +451,16 @@ class SpatialNavigation {
 
   onArrowPress(...args) {
     const component = this.focusableComponents[this.focusKey];
+
+    /* Guard against last-focused component being unmounted at time of onArrowPress (e.g due to UI fading out) */
+    if (!component) {
+      this.log('onArrowPress', 'noComponent');
+
+      return undefined;
+    }
+
+    /* It's okay to navigate AWAY from an item that has lost its 'focused' status, so we don't inspect
+     * component.focusable. */
 
     return component && component.onArrowPressHandler && component.onArrowPressHandler(...args);
   }


### PR DESCRIPTION
This is a guard relevant to the use-case of UI fading out (specifically, when your last-focused component becomes unmounted upon fade-out, which leads to `this.focusableComponents[this.focusKey]` becoming `undefined`).

I prevent `onEnterPress` and `onArrowPress` from triggering if the focusKey no longer corresponds to a component. Otherwise, the app tries to access fields on the `component` variable, which evaluates to `undefined`, and thus results in a TypeError.

"Ideal behaviour" might arguably be to move focus to the next-closest focusable upon the user's current focus target unmounting (this would constitute a separate PR), but in my case, there were no enabled focusables *anywhere* in the app to move the target to, so we'd still need this guard either way.