### PR TITLE
fix(RN): Check for both window and window.add/removeEventListener

### DIFF
--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -375,7 +375,8 @@ class SpatialNavigation {
   }
 
   bindEventHandlers() {
-    if (window) {
+    // We check both because the React Native remote debugger implements window, but not window.addEventListener.
+    if (window && window.addEventListener) {
       this.keyDownEventListener = (event) => {
         if (this.paused === true) {
           return;
@@ -426,7 +427,8 @@ class SpatialNavigation {
   }
 
   unbindEventHandlers() {
-    if (window) {
+    // We check both because the React Native remote debugger implements window, but not window.removeEventListener.
+    if (window && window.removeEventListener) {
       window.removeEventListener('keydown', this.keyDownEventListener);
       this.keyDownEventListener = null;
 


### PR DESCRIPTION
The React Native debugger, which uses the Chrome browser's V8 JS runtime rather than the mobile device's own JS runtime, introduces the `window` object. This means that when debugging a React Native app, we unintentionally pass the `bindEventHandlers` or `unbindEventHandlers` conditional check and throw an error upon attempting to call `window.addEventListener` or `window.removeEventListener` (except on React Native Web), as these methods are only implemented in web browser environments.

 By checking explicitly for both `window` and `window.addEventListener`/`window.removeEventListener`, we safely fail this conditional check on React Native non-web targets while the Chrome debugger is attached.