### PR TITLE
feat: Add event emitter and support a `focusKeyUpdate` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,36 @@ Main HOC wrapper function. Accepts [config](#config) as a param.
 const FocusableComponent = withFocusable({...})(Component);
 ```
 
+#### Events
+
+React Spatial Navigation uses [EventEmitter3](https://github.com/primus/eventemitter3), which implements the [Node.js `EventEmitter` API](https://nodejs.org/api/events.html), with some minor differences noted in the repository's readme.
+
+Add and remove event listeners as follows:
+
+```js
+const callback = (event) => {
+  console.log(`Got "focusKeyUpdate" event`, event);
+};
+spatialNavigation.eventEmitter.addListener('focusKeyUpdate', callback);
+spatialNavigation.eventEmitter.removeListener('focusKeyUpdate', callback);
+```
+
+##### `focusKeyUpdate`
+
+```js
+spatialNavigation.eventEmitter.addListener(
+  'focusKeyUpdate',
+  (event) => {
+    const { lastFocusedKey, newFocusKey } = event;
+    if(lastFocusedKey === newFocusKey){
+      console.log(`setFocus() was called on the same focus key as before; no focus change.`);
+      return;
+    }
+    console.log(`Focus changed from ${lastFocusedKey} -> ${newFocusKey}`);
+  }
+);
+```
+
 #### Config
 ##### `trackChildren`: boolean
 Determine whether to track when any child component is focused. Wrapped component can rely on `hasFocusedChild` prop when this mode is enabled. Otherwise `hasFocusedChild` will be always `false`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6535,6 +6535,11 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-native-web": "^0.11.2"
   },
   "dependencies": {
+    "eventemitter3": "^4.0.0",
     "lodash": "^4.17.13",
     "prop-types": "^15.6.2",
     "recompose": "^0.30.0"

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -1,3 +1,4 @@
+import EventEmitter from 'eventemitter3';
 import filter from 'lodash/filter';
 import first from 'lodash/first';
 import sortBy from 'lodash/sortBy';
@@ -316,6 +317,8 @@ class SpatialNavigation {
     this.visualDebugger = null;
 
     this.logIndex = 0;
+
+    this.eventEmitter = new EventEmitter();
   }
 
   init({
@@ -936,6 +939,14 @@ class SpatialNavigation {
     if (!this.nativeMode) {
       this.updateAllLayouts();
     }
+
+    this.eventEmitter.emit(
+      'focusKeyUpdate',
+      {
+        lastFocusedKey,
+        newFocusKey
+      }
+    );
   }
 
   updateAllLayouts() {


### PR DESCRIPTION
## Added dependency

This adds the [EventEmitter3](https://github.com/primus/eventemitter3) package, which implements the [Node.js `EventEmitter` API](https://nodejs.org/api/events.html), with some minor differences noted in the repository's readme. It is chosen for supporting Node, browser, and React Native environments.

## Use case

It allows you to listen for a `focusKeyUpdate` event, fired any time `setFocus()` is called. This is very useful for debugging what actions in your app lead to `focusKey` changes, particularly in cases such as the currently focused element becoming unmounted (e.g. because a modal appeared or because a focused menu faded out whilst a video was playing).

It is also ideal for keeping a history of focus key changes, either for analytics purposes or for restoring focus to the last-focused item on a screen when a modal is dismissed.

## `focusKeyUpdate` event

The event object has the interface:

```ts
interface FocusKeyUpdateEvent {
    lastFocusedKey: string;
    newFocusKey: string;
}
```

## Example usage

As `focusKeyUpdate` is fired in response to any `setFocus()` call, it is not guaranteed that the new focus key will be different from the previous one. So if the user specifically wants to detect focus key *changes*, they are advised to check whether the `newFocusKey` property differs from the `lastFocusedKey` property on the event.

```js
spatialNavigation.eventEmitter.addListener(
  'focusKeyUpdate',
  (event) => {
    const { lastFocusedKey, newFocusKey } = event;
    if(lastFocusedKey === newFocusKey){
      console.log(`setFocus() was called on the same focus key as before; no focus change.`);
      return;
    }
    console.log(`Focus changed from ${lastFocusedKey} -> ${newFocusKey}`);
  }
);
```