### PR TITLE
added autoRestoreFocus prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.12.0]
 ### Changed
-- added `autoRestoreFocus` prop to restore focus when a component is unmounted and mounted again immediately.
+- added `autoRestoreFocus` prop to control whether parent component should restore focus on any available child when a currently focused child component is unmounted.
 
 ## [2.11.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [2.12.0]
+### Changed
+- added `autoRestoreFocus` prop to restore focus when a component is unmounted and mounted again immediately.
 
 ## [2.11.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ const ParentComponent = (props) => (<View>
     onArrowPress={props.onArrowPress}
     onBecameFocused={props.onItemFocused}
     onBecameBlurred={props.onItemBlurred}
+    autoRestoreFocus={false}
   />
   ...
 </View>);
@@ -337,6 +338,13 @@ const onBlur = ({width, height, x, y, top, left, node}, {prop1, prop2}, {event, 
 />
 ...
 ```
+
+
+##### `autoRestoreFocus`: boolean
+To determine whether parent component should focus the first available child component when currently focused child is unmounted and mounted again. By default when a child component is mounted again, parent component focuses the first child, which could be different from previuosly focused child. 
+When this flag is set to 'false', parent will focus the same component as before, instead of focusing the first child.
+* **true (default)**
+* **false**
 
 ## Props passed to Wrapped Component
 ### `focusKey`: string

--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ Determine whether this component should not remember the last focused child comp
 * **false (default)**
 * **true**
 
+##### `autoRestoreFocus`: boolean
+To determine whether parent component should focus the first available child component when currently focused child is unmounted.
+* **true (default)**
+* **false**
+
 ## Props that can be applied to HOC
 All these props are optional.
 
@@ -244,6 +249,9 @@ All these props are optional.
 Same as in [config](#config).
 
 ### `forgetLastFocusedChild`: boolean
+Same as in [config](#config).
+
+### `autoRestoreFocus`: boolean
 Same as in [config](#config).
 
 ### `focusable`: boolean
@@ -338,13 +346,6 @@ const onBlur = ({width, height, x, y, top, left, node}, {prop1, prop2}, {event, 
 />
 ...
 ```
-
-
-##### `autoRestoreFocus`: boolean
-To determine whether parent component should focus the first available child component when currently focused child is unmounted and mounted again. By default when a child component is mounted again, parent component focuses the first child, which could be different from previuosly focused child. 
-When this flag is set to 'false', parent will focus the same component as before, instead of focusing the first child.
-* **true (default)**
-* **false**
 
 ## Props passed to Wrapped Component
 ### `focusKey`: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "files": [

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -717,6 +717,7 @@ class SpatialNavigation {
     onUpdateFocus,
     onUpdateHasFocusedChild,
     preferredChildFocusKey,
+    autoRestoreFocus,
     focusable
   }) {
     this.focusableComponents[focusKey] = {
@@ -734,6 +735,7 @@ class SpatialNavigation {
       lastFocusedChildKey: null,
       preferredChildFocusKey,
       focusable,
+      autoRestoreFocus,
       layout: {
         x: 0,
         y: 0,
@@ -788,7 +790,7 @@ class SpatialNavigation {
       /**
        * If the component was also focused at this time, focus another one
        */
-      if (isFocused) {
+      if (isFocused && parentComponent.autoRestoreFocus) {
         this.setFocus(parentFocusKey);
       }
     }

--- a/src/withFocusable.js
+++ b/src/withFocusable.js
@@ -18,7 +18,8 @@ const omitProps = (keys) => mapProps((props) => omit(props, keys));
 
 const withFocusable = ({
   forgetLastFocusedChild: configForgetLastFocusedChild = false,
-  trackChildren: configTrackChildren = false
+  trackChildren: configTrackChildren = false,
+  autoRestoreFocus: configAutoRestoreFocus
 } = {}) => compose(
   getContext({
     /**
@@ -109,7 +110,8 @@ const withFocusable = ({
         onUpdateFocus,
         onUpdateHasFocusedChild,
         trackChildren,
-        focusable = true
+        focusable = true,
+        autoRestoreFocus = true
       } = this.props;
 
       const node = SpatialNavigation.isNativeMode() ? this : findDOMNode(this);
@@ -127,6 +129,7 @@ const withFocusable = ({
         onUpdateHasFocusedChild,
         forgetLastFocusedChild: (configForgetLastFocusedChild || forgetLastFocusedChild),
         trackChildren: (configTrackChildren || trackChildren),
+        autoRestoreFocus: configAutoRestoreFocus !== undefined ? configAutoRestoreFocus : autoRestoreFocus,
         focusable
       });
     },
@@ -164,7 +167,8 @@ const withFocusable = ({
     'onUpdateFocus',
     'onUpdateHasFocusedChild',
     'forgetLastFocusedChild',
-    'trackChildren'
+    'trackChildren',
+    'autoRestoreFocus'
   ])
 );
 


### PR DESCRIPTION
`autoRestoreFocus` prop will allow parent component to keep the focus on the same child component even if it's unmounted and mounted again.