### PR TITLE
Fix scroll animations issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.12.1]
+## [2.12.2]
 ### Changed
 - update layouts at the beginning of smartNavigate instead of after setFocus
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.12.1]
 ### Changed
-- update layouts at the beginning of smartNavigate instad of after setFocus
+- update layouts at the beginning of smartNavigate instead of after setFocus
 
 ## [2.12.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.12.1]
+### Changed
+- update layouts at the beginning of smartNavigate instad of after setFocus
+
+## [2.12.1]
 ### Fixed
 - Fixed regression with using `autoRestoreFocus` on components that are focused + getting unmounted and don't have parent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "files": [

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -537,6 +537,10 @@ class SpatialNavigation {
     this.log('smartNavigate', 'fromParentFocusKey', fromParentFocusKey);
     this.log('smartNavigate', 'this.focusKey', this.focusKey);
 
+    if (!this.nativeMode && !fromParentFocusKey) {
+      this.updateAllLayouts();
+    }
+
     const currentComponent = this.focusableComponents[fromParentFocusKey || this.focusKey];
 
     this.log(
@@ -946,10 +950,6 @@ class SpatialNavigation {
     this.setCurrentFocusedKey(newFocusKey, details);
     this.updateParentsHasFocusedChild(newFocusKey, details);
     this.updateParentsLastFocusedChild(lastFocusedKey);
-
-    if (!this.nativeMode) {
-      this.updateAllLayouts();
-    }
   }
 
   updateAllLayouts() {


### PR DESCRIPTION
it fixes wrong layouts if the browser supports smooth scrolling and the application is using it (scroll-behavior: smooth).

in the prev version we were updating the layouts after the focus was set, but if an element is scrolling the position was not updated (because of the animated scroll), with this change it updates the layouts when the smartNavigate function is called, so the layouts are updated at the moment they are used to calculate next focus key