### PR TITLE
Allow throttle for key pressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.3]
+### Changed
+- update throttle for fast clicking and not only for press+hold
+
 ## [2.12.2]
 ### Changed
 - update layouts at the beginning of smartNavigate instead of after setFocus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.12.3]
 ### Changed
-- update throttle for fast clicking via `isThrottledFastClicking` param and not only for press+hold
+- added `throttleKeypresses`, which in combination with `throttle` prevents to stop throttling by `keyup`
+- usefull in case of a fast pressing keys like arrows at a page with a lot of complex elements
 
 ## [2.12.2]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.12.3]
 ### Changed
-- added `throttleKeypresses`, which in combination with `throttle` prevents to stop throttling by `keyup`
-- usefull in case of a fast pressing keys like arrows at a page with a lot of complex elements
+- added `throttleKeypresses` to prevent canceling of throttled events for individual key presses
 
 ## [2.12.2]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.12.3]
 ### Changed
-- update throttle for fast clicking and not only for press+hold
+- update throttle for fast clicking via `isThrottledFastClicking` param and not only for press+hold
 
 ## [2.12.2]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -202,9 +202,15 @@ In Native mode you can only `stealFocus` to some component to flag it as `focuse
 * **true**
 
 ##### `throttle`: integer
-Enable to throttle the function fired by the event listener.
+Enable to throttle the function fired by the event listener `keydown` and stop it by `keyup`.
 
 * **0 (default)**
+
+##### `throttleKeypresses`: boolean
+In combination with `throttle` it prevents to stop throttling by `keyup`.
+The flag is useful in case of a fast pressing keys like arrows at a page with a lot of complex elements.
+
+* **false (default)**
 
 ### `setKeyMap`: function
 Function to set custom key codes.

--- a/README.md
+++ b/README.md
@@ -202,13 +202,12 @@ In Native mode you can only `stealFocus` to some component to flag it as `focuse
 * **true**
 
 ##### `throttle`: integer
-Enable to throttle the function fired by the event listener `keydown` and stop it by `keyup`.
+Enable to throttle the function fired by the event listener.
 
 * **0 (default)**
 
 ##### `throttleKeypresses`: boolean
-In combination with `throttle` it prevents to stop throttling by `keyup`.
-The flag is useful in case of a fast pressing keys like arrows at a page with a lot of complex elements.
+Prevent canceling of throttled events for individual key presses. Works only in combination with `throttle`. Useful when there are issues with the performance of handling rapidly firing navigational events.
 
 * **false (default)**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7251,7 +7251,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7272,12 +7273,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7292,17 +7295,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7419,7 +7425,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7431,6 +7438,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7445,6 +7453,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7452,12 +7461,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7476,6 +7487,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7556,7 +7568,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7568,6 +7581,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7653,7 +7667,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7689,6 +7704,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7708,6 +7724,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7751,12 +7768,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "files": [

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -291,7 +291,7 @@ class SpatialNavigation {
     this.enabled = false;
     this.nativeMode = false;
     this.throttle = 0;
-    this.isThrottledFastClicking = false;
+    this.throttleKeypresses = false;
 
     this.pressedKeys = {};
 
@@ -324,12 +324,12 @@ class SpatialNavigation {
     visualDebug: visualDebug = false,
     nativeMode: nativeMode = false,
     throttle: throttle = 0,
-    isThrottledFastClicking: isThrottledFastClicking = false
+    throttleKeypresses: throttleKeypresses = false
   } = {}) {
     if (!this.enabled) {
       this.enabled = true;
       this.nativeMode = nativeMode;
-      this.isThrottledFastClicking = isThrottledFastClicking;
+      this.throttleKeypresses = throttleKeypresses;
 
       this.debug = debug;
 
@@ -369,7 +369,7 @@ class SpatialNavigation {
       this.enabled = false;
       this.nativeMode = false;
       this.throttle = 0;
-      this.isThrottledFastClicking = false;
+      this.throttleKeypresses = false;
       this.focusKey = null;
       this.parentsHavingFocusedChild = [];
       this.focusableComponents = {};
@@ -438,7 +438,7 @@ class SpatialNavigation {
 
         Reflect.deleteProperty(this.pressedKeys, eventType);
 
-        if (this.throttle && !this.isThrottledFastClicking) {
+        if (this.throttle && !this.throttleKeypresses) {
           this.keyDownEventListener.cancel();
         }
       };

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -433,10 +433,6 @@ class SpatialNavigation {
         const eventType = this.getEventType(event.keyCode);
 
         Reflect.deleteProperty(this.pressedKeys, eventType);
-
-        if (this.throttle) {
-          this.keyDownEventListener.cancel();
-        }
       };
 
       window.addEventListener('keyup', this.keyUpEventListener);

--- a/src/spatialNavigation.js
+++ b/src/spatialNavigation.js
@@ -291,6 +291,7 @@ class SpatialNavigation {
     this.enabled = false;
     this.nativeMode = false;
     this.throttle = 0;
+    this.isThrottledFastClicking = false;
 
     this.pressedKeys = {};
 
@@ -322,11 +323,13 @@ class SpatialNavigation {
     debug: debug = false,
     visualDebug: visualDebug = false,
     nativeMode: nativeMode = false,
-    throttle: throttle = 0
+    throttle: throttle = 0,
+    isThrottledFastClicking: isThrottledFastClicking = false
   } = {}) {
     if (!this.enabled) {
       this.enabled = true;
       this.nativeMode = nativeMode;
+      this.isThrottledFastClicking = isThrottledFastClicking;
 
       this.debug = debug;
 
@@ -366,6 +369,7 @@ class SpatialNavigation {
       this.enabled = false;
       this.nativeMode = false;
       this.throttle = 0;
+      this.isThrottledFastClicking = false;
       this.focusKey = null;
       this.parentsHavingFocusedChild = [];
       this.focusableComponents = {};
@@ -433,6 +437,10 @@ class SpatialNavigation {
         const eventType = this.getEventType(event.keyCode);
 
         Reflect.deleteProperty(this.pressedKeys, eventType);
+
+        if (this.throttle && !this.isThrottledFastClicking) {
+          this.keyDownEventListener.cancel();
+        }
       };
 
       window.addEventListener('keyup', this.keyUpEventListener);


### PR DESCRIPTION
### Issue
- Due to performance issues of handling rapidly firing navigational events, the app can get stuck

### Changed
- Added `throttleKeypresses` to prevent canceling of throttled events for individual key presses