### PR TITLE
feat: useFocusable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -9,7 +9,7 @@ const useFocusContext = () => useContext(FocusContext);
 export function RootProvider({
   children
 }) {
-  const parent = React.useRef(0);
+  const parent = useRef(ROOT_FOCUS_KEY);
   const nextParent = (focusKey) => {
     parent.current = focusKey;
   };
@@ -51,7 +51,7 @@ const useFocusable = ({
     SpatialNavigation.addFocusable({
       focusKey,
       node,
-      parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY,
+      parentFocusKey,
       preferredChildFocusKey,
       onEnterPressHandler,
       onArrowPressHandler,

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -1,7 +1,17 @@
-import {useState, useEffect, useRef} from 'react';
+import React, {useMemo, useState, useEffect, useRef, useContext, createContext} from 'react';
 import noop from 'lodash/noop';
 
 import SpatialNavigation, {ROOT_FOCUS_KEY} from './spatialNavigation';
+
+export const FocusContext = createContext();
+const useFocusContext = () => useContext(FocusContext);
+
+export function RootProvider({ children }) {
+  const parent = React.useRef(0);
+  const nextParent = (focusKey) => (parent.current = focusKey);
+
+  return ( <FocusContext.Provider value={{ parent, nextParent }}>{children}</FocusContext.Provider> )
+}
 
 const useFocusable = ({
   forgetLastFocusedChild,
@@ -9,8 +19,8 @@ const useFocusable = ({
   blockNavigationOut,
   preferredChildFocusKey,
   focusKey,
-  parentFocusKey,
   trackChildren,
+  isParent = false,
   focusable = true,
   onEnterPressHandler = noop,
   onArrowPressHandler = noop,
@@ -20,6 +30,12 @@ const useFocusable = ({
   const nodeRef = useRef(null);
   const [focused, setFocused] = useState(false);
   const [hasFocusedChild, setHasFocusedChild] = useState(false);
+  const { parent, nextParent } = useFocusContext();
+  const parentFocusKey = useRef(parent.current).current;
+
+  useMemo(() => {
+    isParent && nextParent(focusKey);
+  }, []);
 
   useEffect(() => {
     const node = nodeRef.current;

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -1,0 +1,85 @@
+import {useState, useEffect, useRef} from 'react';
+import noop from 'lodash/noop';
+
+import SpatialNavigation, {ROOT_FOCUS_KEY} from './spatialNavigation';
+
+const useFocusable = ({
+  forgetLastFocusedChild,
+  autoRestoreFocus,
+  blockNavigationOut,
+  preferredChildFocusKey,
+  focusKey,
+  parentFocusKey,
+  trackChildren,
+  focusable = true
+}) => {
+  const nodeRef = useRef(null);
+  const [focused, setFocused] = useState(false);
+  const [hasFocusedChild, setHasFocusedChild] = useState(false);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+
+    SpatialNavigation.addFocusable({
+      focusKey,
+      node,
+      parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY,
+      preferredChildFocusKey,
+      onEnterPressHandler: noop,
+      onArrowPressHandler: noop,
+      onBecameFocusedHandler: noop,
+      onBecameBlurredHandler: noop,
+      onUpdateFocus: (isFocused = false) => setFocused(isFocused),
+      onUpdateHasFocusedChild: (isFocused = false) => setHasFocusedChild(isFocused),
+      forgetLastFocusedChild,
+      trackChildren,
+      blockNavigationOut,
+      autoRestoreFocus,
+      focusable
+    });
+
+    return () => {
+      SpatialNavigation.removeFocusable({
+        focusKey
+      });
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+
+    SpatialNavigation.updateFocusable(focusKey, {
+      node,
+      preferredChildFocusKey,
+      focusable,
+      blockNavigationOut
+    });
+  }, [
+    focusKey,
+    preferredChildFocusKey,
+    focusable,
+    blockNavigationOut
+  ]);
+
+  const register = (element) => (nodeRef.current = element);
+
+  const setFocus = () => SpatialNavigation.setFocus(focusKey);
+
+  const navigateByDirection = SpatialNavigation.navigateByDirection;
+  const pauseSpatialNavigation = SpatialNavigation.pause;
+  const resumeSpatialNavigation = SpatialNavigation.resume;
+
+  return {
+    register,
+    setFocus,
+    focused,
+    hasFocusedChild,
+    navigateByDirection,
+    stealFocus: setFocus,
+    pauseSpatialNavigation,
+    resumeSpatialNavigation
+  };
+};
+
+export default useFocusable;

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -11,7 +11,11 @@ const useFocusable = ({
   focusKey,
   parentFocusKey,
   trackChildren,
-  focusable = true
+  focusable = true,
+  onEnterPressHandler = noop,
+  onArrowPressHandler = noop,
+  onBecameFocusedHandler = noop,
+  onBecameBlurredHandler = noop
 }) => {
   const nodeRef = useRef(null);
   const [focused, setFocused] = useState(false);
@@ -25,10 +29,10 @@ const useFocusable = ({
       node,
       parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY,
       preferredChildFocusKey,
-      onEnterPressHandler: noop,
-      onArrowPressHandler: noop,
-      onBecameFocusedHandler: noop,
-      onBecameBlurredHandler: noop,
+      onEnterPressHandler,
+      onArrowPressHandler,
+      onBecameFocusedHandler,
+      onBecameBlurredHandler,
       onUpdateFocus: (isFocused = false) => setFocused(isFocused),
       onUpdateHasFocusedChild: (isFocused = false) => setHasFocusedChild(isFocused),
       forgetLastFocusedChild,

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -6,11 +6,19 @@ import SpatialNavigation, {ROOT_FOCUS_KEY} from './spatialNavigation';
 export const FocusContext = createContext();
 const useFocusContext = () => useContext(FocusContext);
 
-export function RootProvider({ children }) {
+export function RootProvider({
+  children
+}) {
   const parent = React.useRef(0);
-  const nextParent = (focusKey) => (parent.current = focusKey);
+  const nextParent = (focusKey) => {
+    parent.current = focusKey;
+  };
 
-  return ( <FocusContext.Provider value={{ parent, nextParent }}>{children}</FocusContext.Provider> )
+  return (
+    <FocusContext.Provider value={{parent, nextParent}}>
+      {children}
+    </FocusContext.Provider>
+  );
 }
 
 const useFocusable = ({
@@ -30,12 +38,12 @@ const useFocusable = ({
   const nodeRef = useRef(null);
   const [focused, setFocused] = useState(false);
   const [hasFocusedChild, setHasFocusedChild] = useState(false);
-  const { parent, nextParent } = useFocusContext();
+  const {parent, nextParent} = useFocusContext();
   const parentFocusKey = useRef(parent.current).current;
 
   useMemo(() => {
     isParent && nextParent(focusKey);
-  }, []);
+  }, [isParent, focusKey, nextParent]);
 
   useEffect(() => {
     const node = nodeRef.current;


### PR DESCRIPTION
Note: this is not quite ready to merge but wanted to open this pull request as a start to figure out how this can be accomplished. We use this library at work and it would be cool to have a nice hooks implementation.

# useFocusable

An initial implementation of `useFocusable` a hooks based version of the `withFocusable` HOC. This is current working using a ref callback to get the DOM node. It also requires the user to provide the parentFocusKey manually.

### First Note
Because this is using a ref callback instead of `findDomNode` when used with react native components such as `View` the ref isn't going to point at a DOM node even if you are running it in the browser. I'm not familiar with how this library works with React native as it doesn't seem you can ever find the position of a native element when in `nativeMode`?

### Second Note
It would be nice to come up with a solution to not have to pass in parentKey manually. This comes with some challenges when using hooks. I made a suggestion in this [issue thread](https://github.com/NoriginMedia/react-spatial-navigation/issues/77) that would be worth putting a bit of brain power to to figure out if there is a solution.