### PR TITLE
Drop recompose and use withFocusable alongside useFocusable hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2812,6 +2812,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -3592,7 +3593,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -5037,11 +5039,6 @@
         "supports-color": "^2.0.0"
       }
     },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
@@ -5371,7 +5368,8 @@
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6143,6 +6141,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7075,6 +7074,7 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -8084,9 +8084,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -8249,6 +8252,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8679,7 +8683,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -8754,6 +8759,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -9782,7 +9788,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -10082,6 +10089,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -10411,6 +10419,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -10577,7 +10586,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -12560,6 +12570,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -12578,6 +12589,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -12753,11 +12765,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-native-web": {
       "version": "0.11.5",
@@ -13139,19 +13146,6 @@
         "util.promisify": "^1.0.0"
       }
     },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      }
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -13170,7 +13164,8 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -13508,7 +13503,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "safer-eval": {
       "version": "1.3.5",
@@ -13942,7 +13938,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -14535,11 +14532,6 @@
         }
       }
     },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -14897,7 +14889,8 @@
     "ua-parser-js": {
       "version": "0.7.20",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.7.0",
@@ -15300,7 +15293,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.13",
-    "prop-types": "^15.6.2",
-    "recompose": "^0.30.0"
+    "hoist-non-react-statics": "^3.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -60,6 +59,7 @@
     "jest": "^23.6.0",
     "parcel-bundler": "^1.11.0",
     "pre-commit": "^1.2.2",
+    "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-native-web": "^0.11.2"

--- a/src/App.js
+++ b/src/App.js
@@ -122,16 +122,20 @@ const RETURN_KEY = 8;
 const B_KEY = 66;
 
 /* eslint-disable react/prefer-stateless-function */
-class MenuItem extends React.PureComponent {
-  render() {
-    // console.log('Menu item rendered: ', this.props.realFocusKey);
+function MenuItem({focused, register}) {
+  // console.log('Menu item rendered: ', this.props.realFocusKey);
 
-    return (<TouchableOpacity style={[styles.menuItem, this.props.focused ? styles.focusedBorder : null]} />);
-  }
+  return (
+    <TouchableOpacity
+      ref={register}
+      style={[styles.menuItem, focused ? styles.focusedBorder : null]}
+    />
+  );
 }
 
 MenuItem.propTypes = {
-  focused: PropTypes.bool.isRequired
+  focused: PropTypes.bool.isRequired,
+  register: PropTypes.func.isRequired
 
   // realFocusKey: PropTypes.string.isRequired
 };
@@ -143,12 +147,15 @@ class Menu extends React.PureComponent {
     super(props);
 
     this.onPressKey = this.onPressKey.bind(this);
+    this.menuItemRef = React.createRef();
   }
 
   componentDidMount() {
     this.props.setFocus();
 
     window.addEventListener('keydown', this.onPressKey);
+
+    console.log('Test ref forwarding:', this.menuItemRef.current);
   }
 
   componentWillUnmount() {
@@ -170,7 +177,10 @@ class Menu extends React.PureComponent {
       <MenuItemFocusable focusKey={'MENU-3'} />
       <MenuItemFocusable focusKey={'MENU-4'} />
       <MenuItemFocusable focusKey={'MENU-5'} />
-      <MenuItemFocusable focusKey={'MENU-6'} />
+      <MenuItemFocusable
+        focusKey={'MENU-6'}
+        ref={this.menuItemRef}
+      />
     </View>);
   }
 }

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -1,0 +1,85 @@
+import {useState, useEffect, useRef} from 'react';
+import noop from 'lodash/noop';
+
+import SpatialNavigation, {ROOT_FOCUS_KEY} from './spatialNavigation';
+
+const useFocusable = ({
+  forgetLastFocusedChild,
+  autoRestoreFocus,
+  blockNavigationOut,
+  preferredChildFocusKey,
+  focusKey,
+  parentFocusKey,
+  trackChildren,
+  focusable = true
+}) => {
+  const nodeRef = useRef(null);
+  const [focused, setFocused] = useState(false);
+  const [hasFocusedChild, setHasFocusedChild] = useState(false);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+
+    SpatialNavigation.addFocusable({
+      focusKey,
+      node,
+      parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY,
+      preferredChildFocusKey,
+      onEnterPressHandler: noop,
+      onArrowPressHandler: noop,
+      onBecameFocusedHandler: noop,
+      onBecameBlurredHandler: noop,
+      onUpdateFocus: (isFocused = false) => setFocused(isFocused),
+      onUpdateHasFocusedChild: (isFocused = false) => setHasFocusedChild(isFocused),
+      forgetLastFocusedChild,
+      trackChildren,
+      blockNavigationOut,
+      autoRestoreFocus,
+      focusable
+    });
+
+    return () => {
+      SpatialNavigation.removeFocusable({
+        focusKey
+      });
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+
+    SpatialNavigation.updateFocusable(focusKey, {
+      node,
+      preferredChildFocusKey,
+      focusable,
+      blockNavigationOut
+    });
+  }, [
+    focusKey,
+    preferredChildFocusKey,
+    focusable,
+    blockNavigationOut
+  ]);
+
+  const register = (element) => (nodeRef.current = element);
+
+  const setFocus = () => SpatialNavigation.setFocus(focusKey);
+
+  const navigateByDirection = SpatialNavigation.navigateByDirection;
+  const pauseSpatialNavigation = SpatialNavigation.pause;
+  const resumeSpatialNavigation = SpatialNavigation.resume;
+
+  return {
+    register,
+    setFocus,
+    focused,
+    hasFocusedChild,
+    navigateByDirection,
+    stealFocus: setFocus,
+    pauseSpatialNavigation,
+    resumeSpatialNavigation
+  };
+};
+
+export default useFocusable;

--- a/src/useFocusable.js
+++ b/src/useFocusable.js
@@ -11,7 +11,11 @@ const useFocusable = ({
   focusKey,
   parentFocusKey,
   trackChildren,
-  focusable = true
+  focusable = true,
+  onEnterPressHandler = noop,
+  onArrowPressHandler = noop,
+  onBecameFocusedHandler = noop,
+  onBecameBlurredHandler = noop
 }) => {
   const nodeRef = useRef(null);
   const [focused, setFocused] = useState(false);
@@ -25,10 +29,10 @@ const useFocusable = ({
       node,
       parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY,
       preferredChildFocusKey,
-      onEnterPressHandler: noop,
-      onArrowPressHandler: noop,
-      onBecameFocusedHandler: noop,
-      onBecameBlurredHandler: noop,
+      onEnterPressHandler,
+      onArrowPressHandler,
+      onBecameFocusedHandler,
+      onBecameBlurredHandler,
       onUpdateFocus: (isFocused = false) => setFocused(isFocused),
       onUpdateHasFocusedChild: (isFocused = false) => setHasFocusedChild(isFocused),
       forgetLastFocusedChild,

--- a/src/withFocusable.js
+++ b/src/withFocusable.js
@@ -1,181 +1,81 @@
-/* eslint-disable react/no-find-dom-node */
-import {findDOMNode} from 'react-dom';
-import PropTypes from 'prop-types';
-import uniqueId from 'lodash/uniqueId';
-import noop from 'lodash/noop';
-import omit from 'lodash/omit';
-import compose from 'recompose/compose';
-import lifecycle from 'recompose/lifecycle';
-import withHandlers from 'recompose/withHandlers';
-import withContext from 'recompose/withContext';
-import withStateHandlers from 'recompose/withStateHandlers';
-import getContext from 'recompose/getContext';
-import pure from 'recompose/pure';
-import mapProps from 'recompose/mapProps';
-import SpatialNavigation, {ROOT_FOCUS_KEY} from './spatialNavigation';
-
-const omitProps = (keys) => mapProps((props) => omit(props, keys));
+/* eslint-disable react/prop-types */
+import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+import useFocusable, {FocusContext} from './useFocusable';
 
 const withFocusable = ({
   forgetLastFocusedChild: configForgetLastFocusedChild = false,
   trackChildren: configTrackChildren = false,
   autoRestoreFocus: configAutoRestoreFocus,
   blockNavigationOut: configBlockNavigationOut = false
-} = {}) => compose(
-  getContext({
-    /**
-     * From the context provided by another higher-level 'withFocusable' component
-     */
-    parentFocusKey: PropTypes.string
-  }),
+} = {}) => (WrappedComponent) => {
+  const FocusableComponent = React.memo(React.forwardRef(({
+    forgetLastFocusedChild = false,
+    trackChildren = false,
+    autoRestoreFocus = true,
+    blockNavigationOut = false,
+    ...props
+  }, ref) => {
+    const focusState = useFocusable({
+      ...props,
+      forgetLastFocusedChild: (configForgetLastFocusedChild || forgetLastFocusedChild),
+      trackChildren: (configTrackChildren || trackChildren),
+      blockNavigationOut: (configBlockNavigationOut || blockNavigationOut),
+      autoRestoreFocus: configAutoRestoreFocus !== undefined ? configAutoRestoreFocus : autoRestoreFocus
+    });
 
-  withStateHandlers(({focusKey, parentFocusKey}) => {
-    const realFocusKey = focusKey || uniqueId('sn:focusable-item-');
+    // Propagate own 'realFocusKey' as a 'parentFocusKey' to it's children
+    return (
+      <FocusContext.Provider value={focusState.realFocusKey}>
+        <BackwardCompatWithFinDOMNode
+          nodeRef={focusState.register}
+          register={focusState.register}
+        >
+          <WrappedComponent
+            {...props}
+            {...focusState}
+            register={(element) => {
+              focusState.register.current = element;
+              if (ref) {
+                typeof ref === 'function' ? ref(element) : (ref.current = element);
+              }
+            }}
+          />
+        </BackwardCompatWithFinDOMNode>
+      </FocusContext.Provider>
+    );
+  }));
 
-    return {
-      realFocusKey,
+  hoistNonReactStatics(FocusableComponent, WrappedComponent);
+  WrappedComponent.displayName = `Focusable(${WrappedComponent.displayName})`;
 
-      /**
-       * This method is used to imperatively set focus to a component.
-       * It is blocked in the Native mode because the native engine decides what to focus by itself.
-       */
-      setFocus: SpatialNavigation.isNativeMode() ? noop : SpatialNavigation.setFocus.bind(null, realFocusKey),
+  return FocusableComponent;
+};
 
-      navigateByDirection: SpatialNavigation.navigateByDirection,
+/**
+ * Once it is required to assign the `register` callback to the focusable child
+ * element ref this wrapper will not be necessary, but until there is a major
+ * version change this provides backward compatibility and make components
+ * focusable by just wrapping in `withFocusable`.
+ */
+class BackwardCompatWithFinDOMNode extends React.Component {
+  componentDidMount() {
+    this.setNodeRef();
+  }
 
-      /**
-       * In Native mode this is the only way to mark component as focused.
-       * This method always steals focus onto current component no matter which arguments are passed in.
-       */
-      stealFocus: SpatialNavigation.setFocus.bind(null, realFocusKey, realFocusKey),
-      focused: false,
-      hasFocusedChild: false,
-      parentFocusKey: parentFocusKey || ROOT_FOCUS_KEY
-    };
-  }, {
-    onUpdateFocus: () => (focused = false) => ({
-      focused
-    }),
-    onUpdateHasFocusedChild: () => (hasFocusedChild = false) => ({
-      hasFocusedChild
-    })
-  }),
+  componentDidUpdate() {
+    this.setNodeRef();
+  }
 
-  /**
-   * Propagate own 'focusKey' as a 'parentFocusKey' to it's children
-   */
-  withContext({
-    parentFocusKey: PropTypes.string
-  }, ({realFocusKey}) => ({
-    parentFocusKey: realFocusKey
-  })),
-
-  withHandlers({
-    onEnterPressHandler: ({
-      onEnterPress = noop,
-      ...rest
-    }) => (details) => {
-      onEnterPress(rest, details);
-    },
-    onArrowPressHandler: ({
-      onArrowPress = noop,
-      ...rest
-    }) => (direction, details) => onArrowPress(direction, rest, details),
-    onBecameFocusedHandler: ({
-      onBecameFocused = noop,
-      ...rest
-    }) => (layout, details) => {
-      onBecameFocused(layout, rest, details);
-    },
-    onBecameBlurredHandler: ({
-      onBecameBlurred = noop,
-      ...rest
-    }) => (layout, details) => {
-      onBecameBlurred(layout, rest, details);
-    },
-    pauseSpatialNavigation: () => SpatialNavigation.pause,
-    resumeSpatialNavigation: () => SpatialNavigation.resume,
-    updateAllSpatialLayouts: () => SpatialNavigation.updateAllLayouts
-  }),
-
-  lifecycle({
-    componentDidMount() {
-      const {
-        realFocusKey: focusKey,
-        parentFocusKey,
-        preferredChildFocusKey,
-        forgetLastFocusedChild = false,
-        onEnterPressHandler,
-        onArrowPressHandler,
-        onBecameFocusedHandler,
-        onBecameBlurredHandler,
-        onUpdateFocus,
-        onUpdateHasFocusedChild,
-        trackChildren,
-        focusable = true,
-        autoRestoreFocus = true,
-        blockNavigationOut = false
-      } = this.props;
-
-      const node = SpatialNavigation.isNativeMode() ? this : findDOMNode(this);
-
-      SpatialNavigation.addFocusable({
-        focusKey,
-        node,
-        parentFocusKey,
-        preferredChildFocusKey,
-        onEnterPressHandler,
-        onArrowPressHandler,
-        onBecameFocusedHandler,
-        onBecameBlurredHandler,
-        onUpdateFocus,
-        onUpdateHasFocusedChild,
-        forgetLastFocusedChild: (configForgetLastFocusedChild || forgetLastFocusedChild),
-        trackChildren: (configTrackChildren || trackChildren),
-        blockNavigationOut: (configBlockNavigationOut || blockNavigationOut),
-        autoRestoreFocus: configAutoRestoreFocus !== undefined ? configAutoRestoreFocus : autoRestoreFocus,
-        focusable
-      });
-    },
-    componentDidUpdate() {
-      const {
-        realFocusKey: focusKey,
-        preferredChildFocusKey,
-        focusable = true,
-        blockNavigationOut = false
-      } = this.props;
-
-      const node = SpatialNavigation.isNativeMode() ? this : findDOMNode(this);
-
-      SpatialNavigation.updateFocusable(focusKey, {
-        node,
-        preferredChildFocusKey,
-        focusable,
-        blockNavigationOut: (configBlockNavigationOut || blockNavigationOut)
-      });
-    },
-    componentWillUnmount() {
-      const {realFocusKey: focusKey} = this.props;
-
-      SpatialNavigation.removeFocusable({
-        focusKey
-      });
+  setNodeRef() {
+    if (!this.props.nodeRef.current) {
+      this.props.nodeRef.current = this;
     }
-  }),
+  }
 
-  pure,
-
-  omitProps([
-    'onBecameFocusedHandler',
-    'onBecameBlurredHandler',
-    'onEnterPressHandler',
-    'onArrowPressHandler',
-    'onUpdateFocus',
-    'onUpdateHasFocusedChild',
-    'forgetLastFocusedChild',
-    'trackChildren',
-    'autoRestoreFocus'
-  ])
-);
+  render() {
+    return this.props.children;
+  }
+}
 
 export default withFocusable;


### PR DESCRIPTION
This work builds on #79 by @GeraldHost based on [my comment](https://github.com/NoriginMedia/react-spatial-navigation/issues/77#issuecomment-838271550) in #77. It seems to be an alternative to #92, with the added benefit of dropping the Recompose library and supporting ref forwarding through `withFocusable` provided the `register` callback is used in the child component. Using the `register` callback is, however, optional. The only requirement to make a component focusable is still to wrap it in the `withFocusable` HOC as before.

The individual functionalities that were implemented with Recompose have been substituted as follows:

- Config: HOC accepts config options and combines these with the props as before when passed to the hook
- `getContext`: useFocusable takes the parentFocusKey from the FocusContext
- `withStateHandlers`: In useFocusable via useState and returned state is applied as component props
- `withContext`: HOC uses the FocusContext provider to pass the new parent key to children
- `withHandlers`: useFocusable passes these directly to `addFocusable` now, so no need to omit from props later
- `lifecycle`: useFocusable implements this via useEffect
- `pure`: HOC uses React.memo
- `omitProps`: Unnecessary, interal props are removed when destructuring or in the case of handlers never placed on the props object

The `useFocsable` hook has not been exposed as a public API yet, but could be for use in leaf nodes if desired.