### PR TITLE
updateLayout is only called for components affected by navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.9]
+### Changed
+- performance optimization: updateLayout is only called for components affected by navigation
+
 ## [2.12.8]
 ### Added
 - onEnterRelease event triggered when the Enter is released from the focused item

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/react-spatial-navigation",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "description": "HOC-based Spatial Navigation (key navigation) solution for React",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
updateAllLayouts running time increases proportionally to the amount of focusable components in the page, if there are more than 100 there's a sensible decrease in performances.
With this change the layout is updated only for the components that are needed to determine the next focusable element.